### PR TITLE
#160977693 Admin should not be able to update the status of a non-existent order

### DIFF
--- a/server/controllers/orderController.js
+++ b/server/controllers/orderController.js
@@ -117,6 +117,15 @@ class OrderController {
       const dbQuery = 'UPDATE orders SET status=$1 WHERE id=$2';
       await pool.query(dbQuery, [req.status, Number(id)]);
 
+      const orderExists = (await pool.query('SELECT * FROM orders WHERE id=$1', [Number(id)])).rowCount;
+
+      if (!orderExists) {
+        return res.status(404).json({
+          status: 'error',
+          message: 'no order with that id exists',
+        });
+      }
+
       const updatedOrders = (await pool.query('SELECT orders.id, menu.food_name, users.name, orders.date, orders.status FROM orders JOIN menu ON orders.item = menu.id JOIN users ON orders.author = users.id')).rows;
 
       const formattedOrders = orderFormatter(updatedOrders);

--- a/tests/routes/orders.spec.js
+++ b/tests/routes/orders.spec.js
@@ -275,4 +275,19 @@ describe('PUT /orders/:id', () => {
         done();
       });
   });
+
+  it('should not update the status of a non-existent order', (done) => {
+    chai.request(app)
+      .put('/api/v1/orders/2')
+      .set('x-auth', generateValidToken(users.admin))
+      .send({ status: 'complete' })
+      .end((err, res) => {
+        if (err) done(err);
+
+        res.status.should.be.eql(404);
+        res.body.should.be.an('object').which.has.all.keys(['status', 'message']);
+        res.body.should.not.have.keys('order');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

handle edge case where Admin is trying to update the status of an order which hasn't been created yet.

### Description of Task to be completed?

- write new test case to handle this change
- modify PUT /orders/:id to make tests pass


### How should this be manually tested?

#### Clone the project repo, cd into the project directory

```bash
git clone https://github.com/akhilome/fast-food-fast.git && cd fast-food-fast
```

#### install dependencies and setup db

rename `.env.example` to `.env` and configure appropriately, then run 

```bash
npm i && npm run setup-testdb && npm run seed-db
```

* open up postman and sign up for an admin account using the email `hovkard@gmail.com`
* login to the account to get a valid auth token
* send a `PUT` request to `http://localhost:3000/api/v1/orders/1000` providing a `status` of  `complete` in the body section.

### What are the relevant pivotal tracker stories?

#160977693