### PR TITLE
#161101925 Stop showing invalid email

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -38,7 +38,7 @@ class AuthController {
       if (!userExists) {
         return res.status(400).json({
           status: 'error',
-          message: 'no user with that email exists',
+          message: 'invalid email or password provided',
         });
       }
 
@@ -48,7 +48,7 @@ class AuthController {
       if (!correctPassword) {
         return res.status(400).json({
           status: 'error',
-          message: 'incorrect password',
+          message: 'invalid email or password provided',
         });
       }
 

--- a/tests/routes/auth.spec.js
+++ b/tests/routes/auth.spec.js
@@ -149,6 +149,7 @@ describe('POST /auth/login', () => {
 
         res.status.should.eql(400);
         res.body.should.not.have.keys(['auth_token']);
+        res.body.message.should.eql('invalid email or password provided');
         done();
       });
   });
@@ -162,6 +163,7 @@ describe('POST /auth/login', () => {
 
         res.status.should.eql(400);
         res.body.should.not.have.keys(['auth_token']);
+        res.body.message.should.eql('invalid email or password provided');
         done();
       });
   });


### PR DESCRIPTION
### What does this PR do?

Fixes bug where API alerts user during login whether or not the provided email exists in the database

### Description of Task to be completed?

- make error message ambiguous upon provision of invalid email/password during login.

### How should this be manually tested?

* Clone the git repo, and setup project as per described in README
* Start the app by running `npm start` from terminal
* Fire up postman and hit the `http://localhost:3000/api/v1/auth/login/` endpoint providing an *invalid email address or password*

### What are the relevant pivotal tracker stories?

[#161101925](https://www.pivotaltracker.com/story/show/161101925)