### PR TITLE
#161119874 Any User Should be Able to Signup as an Admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ PORT=[server_port_number]
 DATABASE_URL=postgres://[username]@[server]:[port]/fastfoodfast
 TEST_DATABASE_URL=postgres://[username]@[server]:[port]/fastfoodfast_test
 JWT_SECRET=[your_supersecret_secret]
+ADMIN_SECRET=[secret_keyword_admins_should_provide_on_signup]

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -3,8 +3,13 @@ import pool from '../db/config';
 
 class AuthController {
   static async signup(req, res) {
-    const { name, email, password } = req;
-    const isAdmin = email === 'hovkard@gmail.com' ? 't' : 'f';
+    const {
+      name,
+      email,
+      password,
+      adminSecret,
+    } = req;
+    const isAdmin = adminSecret === process.env.ADMIN_SECRET ? 't' : 'f';
 
     try {
       // Check if a user with the provided email already exists

--- a/server/middleware/sanitizer.js
+++ b/server/middleware/sanitizer.js
@@ -7,6 +7,7 @@ class Sanitize {
       email,
       password,
       confirmPassword,
+      adminSecret,
     } = req.body;
 
     const missingFields = [name, email, password, confirmPassword].map((field, index) => {
@@ -36,6 +37,7 @@ class Sanitize {
     req.name = name.trim();
     req.email = email.trim();
     req.password = password.trim();
+    req.adminSecret = adminSecret;
     return next();
   }
 

--- a/tests/routes/auth.spec.js
+++ b/tests/routes/auth.spec.js
@@ -1,9 +1,11 @@
 import chai from 'chai';
 import 'chai/register-should';
 import chaiHttp from 'chai-http';
+import dotenv from 'dotenv';
 import app from '../../server/index';
 import { users, emptyTables } from '../seed/seed';
 
+dotenv.config();
 chai.use(chaiHttp);
 
 before(emptyTables);

--- a/tests/seed/seed.js
+++ b/tests/seed/seed.js
@@ -1,16 +1,14 @@
 import jwt from 'jsonwebtoken';
 import pool from '../../server/db/config';
 
-const adminEmail = 'hovkard@gmail.com';
-
-
 const users = {
   admin: {
     id: 1,
     name: 'Kizito',
-    email: adminEmail,
+    email: 'hovkard@gmail.com',
     password: 'suppersecurepassword',
     confirmPassword: 'suppersecurepassword',
+    adminSecret: process.env.ADMIN_SECRET,
   },
   validUser: {
     id: 2,
@@ -63,7 +61,7 @@ function generateValidToken(userObject) {
     userId: userObject.id,
     userName: userObject.name,
     userEmail: userObject.email,
-    userStatus: userObject.email === adminEmail ? 'admin' : 'customer',
+    userStatus: userObject.adminSecret === process.env.ADMIN_SECRET ? 'admin' : 'customer',
   }, process.env.JWT_SECRET).toString();
 }
 

--- a/tests/seed/seed.js
+++ b/tests/seed/seed.js
@@ -16,6 +16,7 @@ const users = {
     email: 'daniel@james.com',
     password: 'pixel2user',
     confirmPassword: 'pixel2user',
+    adminSecret: '',
   },
   validUserTwo: {
     id: 3,
@@ -23,6 +24,7 @@ const users = {
     email: 'philip@new.man',
     password: 'facilitate',
     confirmPassword: 'facilitate',
+    adminSecret: '',
   },
   validUserInvalidPass: {
     email: 'daniel@james.com',


### PR DESCRIPTION
### What does this PR do?

implements functionality which allow any user who has a valid `adminSecret` signup as an admin on the app.

### Description of Task to be completed?

- modify tests and test seed data to accommodate new changes
- modify POST /auth/signup implementation to allow other users to signup as admin
- add admin secret as an environmental variable

### How should this be manually tested?

* Clone the git repo, and setup project as per described in README
* Start the app by running `npm start` from the terminal
* Fire up postman and hit the `http://localhost:3000/api/v1/auth/signup/` endpoint providing the following fields:
  - `name`
  - `email`
  - `password`
  - `confirmPassword`
  - `adminSecret`

### What are the relevant pivotal tracker stories?

[#161119874](https://www.pivotaltracker.com/story/show/161119874)

### Screenshots

![image](https://user-images.githubusercontent.com/15332525/46766055-bbc43380-ccd8-11e8-8beb-f5776751747b.png)
