### PR TITLE
#161145781 Unauthenticated Users should be able to see menu

### DIFF
--- a/server/routes/menuRouter.js
+++ b/server/routes/menuRouter.js
@@ -5,7 +5,7 @@ import Sanitize from '../middleware/sanitizer';
 
 const router = new Router();
 
-router.get('/', AuthHandler.authorize, MenuController.getMenu);
+router.get('/', MenuController.getMenu);
 router.post(
   '/',
   AuthHandler.authorize,

--- a/tests/routes/menu.spec.js
+++ b/tests/routes/menu.spec.js
@@ -92,15 +92,16 @@ describe('GET /menu', () => {
       });
   });
 
-  it('should not get menu if user not logged in', (done) => {
+  it('should still get menu if user not logged in', (done) => {
     chai.request(app)
       .get('/api/v1/menu')
       .set('x-auth', '')
       .end((err, res) => {
         if (err) done(err);
 
-        res.status.should.eql(401);
-        res.body.status.should.eql('error');
+        res.status.should.eql(200);
+        res.body.message.should.eql('menu fetched successfully');
+        res.body.menu.should.be.an('array');
         done();
       });
   });


### PR DESCRIPTION
### What does this PR do?

Modifies the `GET /menu` endpoint to allow users who are not logged in/don't have an account (_potential customers_) see the list of currently available food items.

### Description of Task to be completed?

- modify test assertions based on the new criterion
- modify endpoint to make tests pass

### How should this be manually tested?

* Clone the git repo, and setup project as per described in README
* Start the app by running `npm start` from the terminal
* Fire up postman and hit the `GET http://localhost:3000/api/v1/menu` endpoint with no `x-auth` token

### What are the relevant pivotal tracker stories?

[#161145781](https://www.pivotaltracker.com/story/show/161145781)

### Screenshots

![image](https://user-images.githubusercontent.com/15332525/46800371-57908680-cd4f-11e8-871b-3a4d2a4d6200.png)
