### PR TITLE
#161217252 Fix response object format for /auth routes

### DIFF
--- a/server/middleware/authHandler.js
+++ b/server/middleware/authHandler.js
@@ -22,8 +22,10 @@ class AuthHandler {
     res.status(200).json({
       status: 'success',
       message: 'user logged in successfully',
-      id: userId,
-      auth_token: token,
+      user: {
+        id: userId,
+        auth_token: token,
+      },
     });
   }
 

--- a/tests/routes/auth.spec.js
+++ b/tests/routes/auth.spec.js
@@ -19,9 +19,10 @@ describe('POST /auth/signup', () => {
         if (err) done(err);
 
         res.status.should.eql(200);
-        res.body.should.be.an('object').that.has.keys(['status', 'message', 'id', 'auth_token']);
+        res.body.should.be.an('object').that.has.keys(['status', 'message', 'user']);
         res.body.status.should.eql('success');
-        res.body.id.should.eql(users.admin.id);
+        res.body.user.should.be.an('object').that.has.keys(['id', 'auth_token']);
+        res.body.user.id.should.eql(users.admin.id);
         done();
       });
   });
@@ -34,9 +35,10 @@ describe('POST /auth/signup', () => {
         if (err) done(err);
 
         res.status.should.eql(200);
-        res.body.should.be.an('object').that.has.keys(['status', 'message', 'id', 'auth_token']);
+        res.body.should.be.an('object').that.has.keys(['status', 'message', 'user']);
         res.body.status.should.eql('success');
-        res.body.id.should.eql(users.validUser.id);
+        res.body.user.should.be.an('object').that.has.keys(['id', 'auth_token']);
+        res.body.user.id.should.eql(users.validUser.id);
         done();
       });
   });
@@ -121,8 +123,9 @@ describe('POST /auth/login', () => {
         if (err) done(err);
 
         res.status.should.eql(200);
-        res.body.should.be.an('object').which.has.keys(['status', 'message', 'id', 'auth_token']);
-        res.body.id.should.eql(users.validUser.id);
+        res.body.should.be.an('object').which.has.keys(['status', 'message', 'user']);
+        res.body.user.should.be.an('object').which.has.keys(['id', 'auth_token']);
+        res.body.user.id.should.eql(users.validUser.id);
         done();
       });
   });
@@ -147,7 +150,7 @@ describe('POST /auth/login', () => {
         if (err) done(err);
 
         res.status.should.eql(400);
-        res.body.should.not.have.keys(['auth_token']);
+        res.body.should.not.have.keys(['user']);
         res.body.message.should.eql('invalid email or password provided');
         done();
       });
@@ -161,7 +164,7 @@ describe('POST /auth/login', () => {
         if (err) done(err);
 
         res.status.should.eql(400);
-        res.body.should.not.have.keys(['auth_token']);
+        res.body.should.not.have.keys(['user']);
         res.body.message.should.eql('invalid email or password provided');
         done();
       });
@@ -175,7 +178,7 @@ describe('POST /auth/login', () => {
         if (err) done(err);
 
         res.status.should.eql(400);
-        res.body.should.not.have.keys(['auth_token']);
+        res.body.should.not.have.keys(['user']);
         done();
       });
   });


### PR DESCRIPTION
### What does this PR do?

update response object format for `POST /auth/signup` and `POST /auth/login` routes

### Description of Task to be completed?

- modify tests to reflect correct format
- modify authHandler response to make tests pass

### How should this be manually tested?

* Clone the git repo, and setup project as per described in README
* Start the app by running `npm start` from the terminal
* Fire up postman and hit the `http://localhost:3000/api/v1/auth/signup/` endpoint providing the required fields as pointed out in the API's [documentation](https://kiakiafood.docs.apiary.io/#reference/0/authentication/create-an-account)

### What are the relevant pivotal tracker stories?

[#161217252](https://www.pivotaltracker.com/story/show/161217252)

### Screenshots

![image](https://user-images.githubusercontent.com/15332525/46951544-36e26c80-d080-11e8-8701-c4a77d0bc3be.png)
